### PR TITLE
Remove use of deprecated meals.data

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -52,7 +52,7 @@ class User extends ApplicationModel
         return DB::table('registrations')
                 ->leftJoin('meals', 'registrations.meal_id', '=', 'meals.id')
                 ->where('user_id', '=', $this->id)
-                ->where('meals.date', '>=', date('Y-m-d', $timestamp))
+                ->where('meals.meal_timestamp', '>=', date('Y-m-d', $timestamp))
                 ->whereNull('registrations.deleted_at')
                 ->whereNull('meals.deleted_at')
                 ->count();


### PR DESCRIPTION
The column meals.data is deprecated and should be replaced with meals.meal_timestamp. Should fix bug in user profile which displays an incorrect count of total meals.
