### PR TITLE
Remove use of deprecated meals.data

### DIFF
--- a/resources/views/profile/index.php
+++ b/resources/views/profile/index.php
@@ -61,7 +61,7 @@
 <div class="profile">
     <h2>Maaltijden waar je hebt gegeten</h2>
     <ul>
-        <?php foreach ($user->registrations()->join('meals', 'registrations.meal_id', '=', 'meals.id')->orderBy('date', 'desc')->get() as $registration): ?>
+        <?php foreach ($user->registrations()->join('meals', 'registrations.meal_id', '=', 'meals.id')->orderBy('meal_timestamp', 'desc')->get() as $registration): ?>
             <li><?= $registration->longDate(); ?></li>
         <?php endforeach; ?>
     </ul>


### PR DESCRIPTION
Use meal.meal_timestamp to correctly sort meals in profile.
