### PR TITLE
Migrate from Laravel Mix to Vite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /node_modules
 /public/hot
+/public/build
 /public/storage
 /storage/*.key
 /vendor

--- a/deploy.php
+++ b/deploy.php
@@ -19,7 +19,7 @@ host('noms.debolk.nl')
 task('build:frontend', function () {
     within('{{release_path}}', function () {
         run('npm install');
-        run('npm run production');
+        run('npm run build');
     });
 });
 before('deploy:publish', 'build:frontend');

--- a/package.json
+++ b/package.json
@@ -1,11 +1,8 @@
 {
     "private": true,
     "scripts": {
-        "development": "mix",
-        "watch": "mix watch",
-        "watch-poll": "mix watch -- --watch-options-poll=1000",
-        "hot": "mix watch --hot",
-        "production": "mix --production"
+        "dev": "vite",
+        "build": "vite build"
     },
     "devDependencies": {
         "cross-env": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -9,12 +9,13 @@
     },
     "devDependencies": {
         "cross-env": "^7.0.3",
-        "laravel-mix": "^6.0.49",
         "postcss": "^8.4.14",
         "resolve-url-loader": "^4.0.0",
         "sass": "^1.53.0",
         "sass-loader": "^12.6.0",
-        "vue-template-compiler": "^2.7.4"
+        "vue-template-compiler": "^2.7.4",
+        "vite": "^3.0.2",
+        "laravel-vite-plugin": "^0.6.0"
     },
     "dependencies": {
         "sweetalert2": "^11.4.20"

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -12,7 +12,7 @@
 
     <link href="https://fonts.googleapis.com/css?family=Nunito" rel="stylesheet">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
-    <link rel="stylesheet" type="text/css" href="{{ mix('css/app.css') }}">
+    @vite('resources/css/app.css')
 
     <title>@yield('title') - Bolknoms</title>
 </head>
@@ -41,6 +41,6 @@
     <script src="https://code.jquery.com/jquery-3.4.1.min.js"
             integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo="
             crossorigin="anonymous"></script>
-    <script type="text/javascript" src="{{ mix('js/app.js') }}"></script>
+    @vite('resources/js/app.js')
 </body>
 </html>

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vite';
+import laravel from 'laravel-vite-plugin';
+
+export default defineConfig({
+    plugins: [
+        laravel({
+            input: [
+                'resources/sass/bootstrap.scss',
+                'resources/js/bootstrap.js',
+            ],
+            refresh: true,
+        }),
+    ],
+});

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -1,6 +1,0 @@
-const mix = require('laravel-mix');
-
-mix.js('resources/js/bootstrap.js', 'public/js/app.js').sourceMaps().version();
-mix.sass('resources/sass/bootstrap.scss', 'public/css/app.css').sourceMaps().version();
-
-mix.disableSuccessNotifications();


### PR DESCRIPTION
This pull request includes changes for migrating from Laravel Mix to Vite outlined in [Migration Guide](https://github.com/laravel/vite-plugin/blob/main/UPGRADE.md#migrating-from-laravel-mix-to-vite) and automated by the [Vite Converter](https://laravelshift.com/convert-laravel-mix-to-vite).

**Before merging**, you need to:

- Checkout the `shift-143570` branch
- Run `composer update`
- Run `npm install`
- Review **all** comments for additional changes 
- Thoroughly test your application ([no tests?](https://laravelshift.com/laravel-test-generator), [no CI?](https://laravelshift.com/ci-generator))

Please send your feedback to shift@laravelshift.com or share the good vibes on [Twitter](https://twitter.com/laravelshift).
